### PR TITLE
Add PyPI pubilshing workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -37,7 +37,6 @@ jobs:
 
   publish-to-pypi:
     name: Publish to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
     - build
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,84 @@
+name: Publish TestPyPI
+on:
+  push:
+    branches:
+      - main
+      - ci/pypi-publishing
+    tags:
+      - '*'
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
+    - name: Set up Poetry
+      uses: abatilo/actions-poetry@v3
+      with:
+        poetry-version: 1.8.4
+
+    - name: Install dependencies
+      run: poetry install
+
+    - name: Build distribution
+      run: poetry build
+
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: Publish to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tws-sdk
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish dists to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-to-testpypi:
+    name: Publish to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/tws-sdk
+
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish dists to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,6 @@
-name: Publish TestPyPI
+name: Publish to PyPI
 on:
   push:
-    branches:
-      - main
-      - ci/pypi-publishing
     tags:
       - '*'
 jobs:
@@ -58,27 +55,3 @@ jobs:
         path: dist/
     - name: Publish dists to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-
-  publish-to-testpypi:
-    name: Publish to TestPyPI
-    needs:
-    - build
-    runs-on: ubuntu-latest
-
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/tws-sdk
-
-    permissions:
-      id-token: write
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Publish dists to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: poetry install
 
+      - name: Build distribution
+        run: poetry build
+
       - name: Add Poetry Python binary to PATH
         run: echo "$(poetry env info --path)/bin" >> $GITHUB_PATH
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,64 @@
 
 Python client for [TWS](https://www.tuneni.ai).
 
+## Installation
+
+```bash
+pip install tws-sdk
+```
 
 ## Usage
 
-TBC
+The library provides both synchronous and asynchronous clients for interacting with TWS.
+
+The primary API is `run_workflow`, which executes a workflow configured via the TWS UI, waits for completion,
+and returns the result.
+
+### Synchronous Usage
+
+```python
+from tws import create_client
+
+# Create a client instance
+client = create_client(
+    public_key="your_public_key",
+    secret_key="your_secret_key",
+    api_url="your_api_url"
+)
+
+# Run a workflow and wait for completion
+result = client.run_workflow(
+    workflow_definition_id="your_workflow_id",
+    workflow_args={
+        "param1": "value1",
+        "param2": "value2"
+    },
+)
+```
+
+### Asynchronous Usage
+
+The signatures are exactly the same for async usage, but the client is created using `create_async_client` and client
+methods are awaited.
+
+```python
+from tws import create_async_client
+
+
+async def main():
+    # Create an async client instance
+    client = await create_async_client(
+        public_key="your_public_key",
+        secret_key="your_secret_key",
+        api_url="your_api_url"
+    )
+
+    # Run a workflow and wait for completion
+    result = await client.run_workflow(
+        workflow_definition_id="your_workflow_id",
+        workflow_args={
+            "param1": "value1",
+            "param2": "value2"
+        },
+    )
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.poetry]
-name = "tws"
+name = "tws-sdk"
 version = "0.1.0"
 description = "TWS client for Python."
 authors = ["Fireline Science <sean@firelinescience.com>"]
@@ -12,6 +12,9 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent"
+]
+packages = [
+    {include = "tws"}
 ]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Will now publish to PyPI automatically on tag / release.

Initially I set it up to also publish to Test PyPI, but since [supabase-py](https://pypi.org/project/supabase/) doesn't seem to publish there, installation of tws-sdk  from Test PyPI fails since it can't resolve dependencies. So, not much point in releasing there.

Also added some initial usage docs so the PyPI page looks decent, though we'll need to continue iterating on those.